### PR TITLE
minor fix regarding how CodeBuild packs the artifact

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -17,3 +17,5 @@ phases:
 artifacts:
   files:
     - target/VijayJavaHelloWorld.war
+    - appspec.yml
+    - scripts/*


### PR DESCRIPTION
Hi there!

Felipe from AWS here.

Is it required to pack your appspec.yml and your scripts inside your artifact at your build step in CodeBuild. I have commited the fix and send as a pull request as a reference for you :)

The Artifacts section of your buildspec.yml will dictate what will be packed in your CodeDeploy application bundle. Since CodeDeploy requires to have appspec.yml and the scripts that are part of your deployment procedure, you will need to pack them as part of the artifact as well.

Please feel free to adapt/merge and use it as you wish. I have tested here on my side and worked perfectly!

Have a great day further!